### PR TITLE
[POC] FileTree sorting

### DIFF
--- a/contao/config/database.sql
+++ b/contao/config/database.sql
@@ -17,6 +17,7 @@ CREATE TABLE `tl_metamodel_attribute` (
   `file_uploadFolder` blob NULL,
   `file_validFileTypes` varchar(255) NOT NULL default '',
   `file_filesOnly` char(1) NOT NULL default '',
+  `file_orderField` int(10) unsigned NOT NULL default '0'
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 --

--- a/contao/config/event_listeners.php
+++ b/contao/config/event_listeners.php
@@ -11,6 +11,7 @@
  * @subpackage AttributeFile
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Andreas Isaak <info@andreas-isaak.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -18,6 +19,9 @@
 
 use MetaModels\Attribute\File\AttributeTypeFactory;
 use MetaModels\Attribute\Events\CreateAttributeFactoryEvent;
+use MetaModels\Attribute\File\FileOrderAttributeTypeFactory;
+use MetaModels\Attribute\File\Subscriber;
+use MetaModels\Events\MetaModelsBootEvent;
 use MetaModels\MetaModelsEvents;
 
 return array
@@ -26,6 +30,12 @@ return array
         function (CreateAttributeFactoryEvent $event) {
             $factory = $event->getFactory();
             $factory->addTypeFactory(new AttributeTypeFactory());
+            $factory->addTypeFactory(new FileOrderAttributeTypeFactory());
         }
-    )
+    ),
+    MetaModelsEvents::SUBSYSTEM_BOOT_BACKEND => array(
+        function (MetaModelsBootEvent $event) {
+            new Subscriber($event->getServiceContainer());
+        }
+    ),
 );

--- a/contao/dca/tl_metamodel_attribute.php
+++ b/contao/dca/tl_metamodel_attribute.php
@@ -11,6 +11,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Andreas Isaak <info@andreas-isaak.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -21,9 +22,11 @@ $GLOBALS['TL_DCA']['tl_metamodel_attribute']['metapalettes']['file extends _simp
     '+advanced'               => array('file_customFiletree', 'file_multiple'),
 );
 
+$GLOBALS['TL_DCA']['tl_metamodel_attribute']['metapalettes']['fileOrder extends _simpleattribute_'] = array();
+
 $GLOBALS['TL_DCA']['tl_metamodel_attribute']['metasubpalettes']['file_customFiletree'] = array
 (
-    'file_uploadFolder', 'file_validFileTypes', 'file_filesOnly'
+    'file_uploadFolder', 'file_validFileTypes', 'file_filesOnly', 'file_orderField'
 );
 
 $GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['file_customFiletree'] = array
@@ -60,4 +63,11 @@ $GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['file_filesOnly'] = array
     'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_filesOnly'],
     'inputType'               => 'checkbox',
     'eval'                    => array('tl_class' => 'w50 m12')
+);
+
+$GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['file_orderField'] = array
+(
+    'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_orderField'],
+    'inputType'               => 'select',
+    'eval'                    => array('tl_class' => 'w50')
 );

--- a/contao/languages/en/tl_metamodel_attribute.php
+++ b/contao/languages/en/tl_metamodel_attribute.php
@@ -9,20 +9,24 @@
  * @package    MetaModels
  * @subpackage AttributeFile
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
  */
 
 // Fields.
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['typeOptions']['file']    = 'File';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_customFiletree'][0] = 'Customize the file tree';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_customFiletree'][1] = 'Allows you to set custom options for the filetree.';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_uploadFolder'][0]   = 'Set file root folder';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_uploadFolder'][1]   = 'Selects the root point from which the user will select this file field.';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_validFileTypes'][0] = 'Valid file types';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_validFileTypes'][1] = 'To overwrite the contao standard file types, please enter a comma separated list of extensions of valid file types for this field.';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_filesOnly'][0]      = 'Allow files only';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_filesOnly'][1]      = 'Select this option to restrict the file browser to files only (folders not selectable).';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_multiple'][0]       = 'Multiple selection';
-$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_multiple'][1]       = 'If selected, user will be able to select more than one item.';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['typeOptions']['file']      = 'File';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['typeOptions']['fileOrder'] = 'File tree order';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_customFiletree'][0]   = 'Customize the file tree';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_customFiletree'][1]   = 'Allows you to set custom options for the filetree.';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_uploadFolder'][0]     = 'Set file root folder';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_uploadFolder'][1]     = 'Selects the root point from which the user will select this file field.';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_validFileTypes'][0]   = 'Valid file types';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_validFileTypes'][1]   = 'To overwrite the contao standard file types, please enter a comma separated list of extensions of valid file types for this field.';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_filesOnly'][0]        = 'Allow files only';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_filesOnly'][1]        = 'Select this option to restrict the file browser to files only (folders not selectable).';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_multiple'][0]         = 'Multiple selection';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_multiple'][1]         = 'If selected, user will be able to select more than one item.';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_orderField'][0]       = 'Order field';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['file_orderField'][1]       = 'Select an orderField attribute to enable file ordering.';

--- a/src/MetaModels/Attribute/File/File.php
+++ b/src/MetaModels/Attribute/File/File.php
@@ -18,6 +18,7 @@
  * @author     MrTool <github@r2pi.de>
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -85,6 +86,7 @@ class File extends BaseSimple
             'file_uploadFolder',
             'file_validFileTypes',
             'file_filesOnly',
+            'file_orderField',
             'filterable',
             'searchable',
             'mandatory',
@@ -170,6 +172,11 @@ class File extends BaseSimple
         $arrFieldDef['eval']['files']      = true;
         $arrFieldDef['eval']['extensions'] = \Config::get('allowedDownload');
         $arrFieldDef['eval']['multiple']   = (bool) $this->get('file_multiple');
+
+        $orderFileAttribute = $this->getMetaModel()->getAttributeById($this->get('file_orderField'));
+        if ($orderFileAttribute) {
+            $arrFieldDef['eval']['orderField'] = $orderFileAttribute->getColName();
+        }
 
         if ($this->get('file_multiple')) {
             $arrFieldDef['eval']['fieldType'] = 'checkbox';

--- a/src/MetaModels/Attribute/File/FileOrder.php
+++ b/src/MetaModels/Attribute/File/FileOrder.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * The MetaModels extension allows the creation of multiple collections of custom items,
+ * each with its own unique set of selectable attributes, with attribute extendability.
+ * The Front-End modules allow you to build powerful listing and filtering of the
+ * data in each collection.
+ *
+ * PHP version 5
+ *
+ * @package    MetaModels
+ * @subpackage AttributeFile
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace MetaModels\Attribute\File;
+
+use MetaModels\Attribute\BaseSimple;
+
+/**
+ * FileOrder is a helper attribute for the file attribute.
+ *
+ * @package MetaModels\Attribute\File
+ */
+class FileOrder extends BaseSimple
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldDefinition($arrOverrides = array())
+    {
+        $arrFieldDef = parent::getFieldDefinition($arrOverrides);
+
+        $arrFieldDef['inputType'] = 'fileTreeOrder';
+
+        return $arrFieldDef;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDataType()
+    {
+        return 'blob NULL';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function widgetToValue($varValue, $itemId)
+    {
+        $varValue = $this->unserializeData($varValue);
+
+        return $varValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseValue($arrRowData, $strOutputFormat = 'text', $objSettings = null)
+    {
+        $arrResult = array(
+            'raw'  => $arrRowData[$this->getColName()],
+            'text' => implode(', ', array_map('String::binToUuid', array_filter($arrRowData[$this->getColName()])))
+        );
+
+        return $arrResult;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserializeData($value)
+    {
+        if (!is_array($value)) {
+            $deserialized = deserialize($value);
+
+            if (is_array($deserialized)) {
+                $value = $deserialized;
+            } else {
+                $value = explode(',', $value);
+            }
+        }
+
+        return array_map(
+            function ($value) {
+                if (!\Validator::isBinaryUuid($value)) {
+                    $value = \String::uuidToBin($value);
+                }
+
+                return $value;
+            },
+            $value
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serializeData($value)
+    {
+        return serialize($value);
+    }
+}

--- a/src/MetaModels/Attribute/File/FileOrderAttributeTypeFactory.php
+++ b/src/MetaModels/Attribute/File/FileOrderAttributeTypeFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * The MetaModels extension allows the creation of multiple collections of custom items,
+ * each with its own unique set of selectable attributes, with attribute extendability.
+ * The Front-End modules allow you to build powerful listing and filtering of the
+ * data in each collection.
+ *
+ * PHP version 5
+ *
+ * @package    MetaModels
+ * @subpackage AttributeFile
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace MetaModels\Attribute\File;
+
+use MetaModels\Attribute\AbstractAttributeTypeFactory;
+
+/**
+ * Attribute type factory for file attributes.
+ */
+class FileOrderAttributeTypeFactory extends AbstractAttributeTypeFactory
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->typeName  = 'fileOrder';
+        $this->typeIcon  = 'system/modules/metamodelsattribute_file/html/file.png';
+        $this->typeClass = 'MetaModels\Attribute\File\FileOrder';
+    }
+}

--- a/src/MetaModels/Attribute/File/Subscriber.php
+++ b/src/MetaModels/Attribute/File/Subscriber.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * The MetaModels extension allows the creation of multiple collections of custom items,
+ * each with its own unique set of selectable attributes, with attribute extendability.
+ * The Front-End modules allow you to build powerful listing and filtering of the
+ * data in each collection.
+ *
+ * PHP version 5
+ *
+ * @package    MetaModels
+ * @subpackage AttributeFile
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace MetaModels\Attribute\File;
+
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPropertyOptionsEvent;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use MetaModels\DcGeneral\Events\BaseSubscriber;
+use MetaModels\IMetaModel;
+
+/**
+ * Subscriber integrates file attribute related listeners.
+ *
+ * @package MetaModels\Attribute\File
+ */
+class Subscriber extends BaseSubscriber
+{
+    /**
+     * The meta models cache.
+     *
+     * @var array
+     */
+    private $metaModelCache = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerEventsInDispatcher()
+    {
+        $this->addListener(
+            GetPropertyOptionsEvent::NAME,
+            array($this, 'getFileOrderAttributes')
+        );
+    }
+
+    /**
+     * Get file order attributes.
+     *
+     * @param GetPropertyOptionsEvent $event The event.
+     *
+     * @void
+     */
+    public function getFileOrderAttributes(GetPropertyOptionsEvent $event)
+    {
+        if (($event->getEnvironment()->getDataDefinition()->getName() !== 'tl_metamodel_attribute')
+            || ($event->getPropertyName() !== 'file_orderField')) {
+            return;
+        }
+
+        $database  = $this->getDatabase();
+        $model     = $event->getModel();
+        $metaModel = $this->getMetaModel($model);
+
+        if (!$metaModel) {
+            return;
+        }
+
+        $options = array();
+
+        // Fetch all attributes that exist in other settings.
+        $alreadyTaken = $database
+            ->prepare('
+            SELECT
+                file_orderField
+            FROM
+                ' . $model->getProviderName() . '
+            WHERE
+                type=?
+                AND id<>?
+                AND pid=?')
+            ->execute(
+                $model->getProperty('type'),
+                $model->getProperty('attr_id'),
+                $model->getProperty('pid')
+            )
+            ->fetchEach('attr_id');
+
+        foreach ($metaModel->getAttributes() as $attribute) {
+            if ($attribute->get('type') !== 'fileOrder' || in_array($attribute->get('id'), $alreadyTaken)) {
+                continue;
+            }
+            $options[$attribute->get('id')] = sprintf(
+                '%s [%s]',
+                $attribute->getName(),
+                $attribute->get('type')
+            );
+        }
+
+        $event->setOptions($options);
+    }
+
+
+    /**
+     * Retrieve the MetaModel instance from a render settings model.
+     *
+     * @param ModelInterface $model The model to fetch the MetaModel instance for.
+     *
+     * @return IMetaModel
+     */
+    protected function getMetaModel($model)
+    {
+        if (!isset($this->metaModelCache[$model->getProperty('pid')])) {
+            $dbResult = $this
+                ->getDatabase()
+                ->prepare('SELECT * FROM tl_metamodel_rendersettings WHERE id=?')
+                ->execute($model->getProperty('pid'))
+                ->row();
+
+            $this->metaModelCache[$model->getProperty('pid')] = $this->getMetaModelById($dbResult['pid']);
+        }
+
+        return $this->metaModelCache[$model->getProperty('pid')];
+    }
+}


### PR DESCRIPTION
This pull requests provides a **proof of concept** to support fully file tree sorting as Contao does (See #8).

It provides a separate file tree order attribute which has to be created for each file attribute which should be sortable. Required changes in the DCG are already published as PR.

The sorting is not applied when rendering the file attribute yet. I'll provide it if the concept is accepted.

There could be some improvements by hacking the order attribute automatically into the information list by using `CollectMetaModelAttributeInformationEvent`. The file attribute then have to be responsible to create the sql field.

As a side effect the `isGallery` option can be added and would solve #33.