### PR TITLE
[WIP] Support different FEE file widgets

### DIFF
--- a/contao/config/event_listeners.php
+++ b/contao/config/event_listeners.php
@@ -35,7 +35,7 @@ return array
     GetPropertyOptionsEvent::NAME => array(
         function (GetPropertyOptionsEvent $event) {
             if (('tl_metamodel_dcasetting' !== $event->getEnvironment()->getDataDefinition()->getName())
-                || ('fee_widget' !== $event->getPropertyName())) {
+                || ('fe_widget' !== $event->getPropertyName())) {
                 return;
             }
 

--- a/contao/config/event_listeners.php
+++ b/contao/config/event_listeners.php
@@ -19,6 +19,7 @@
  * @filesource
  */
 
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPropertyOptionsEvent;
 use MetaModels\Attribute\File\AttributeTypeFactory;
 use MetaModels\Attribute\Events\CreateAttributeFactoryEvent;
 use MetaModels\MetaModelsEvents;
@@ -29,6 +30,26 @@ return array
         function (CreateAttributeFactoryEvent $event) {
             $factory = $event->getFactory();
             $factory->addTypeFactory(new AttributeTypeFactory());
+        }
+    ),
+    GetPropertyOptionsEvent::NAME => array(
+        function (GetPropertyOptionsEvent $event) {
+            if (('tl_metamodel_dcasetting' !== $event->getEnvironment()->getDataDefinition()->getName())
+                || ('fee_widget' !== $event->getPropertyName())) {
+                return;
+            }
+
+            $options = [];
+            foreach ($GLOBALS['TL_FFL'] as $ffl => $fflClass) {
+                if (in_array(
+                    'MetaModels\Attribute\File\Contao\Widget\IFileWidget',
+                    class_implements($fflClass, true)
+                )) {
+                    $options[] = $ffl;
+                }
+            }
+
+            $event->setOptions($options);
         }
     )
 );

--- a/contao/dca/tl_metamodel_dcasetting.php
+++ b/contao/dca/tl_metamodel_dcasetting.php
@@ -31,11 +31,13 @@ $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['metasubselectpalettes']['attr_id'
 );
 
 if (in_array('metamodels-contao-frontend-editing', \Contao\ModuleLoader::getActive())) {
-    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['metasubselectpalettes']['attr_id']['file']['functions'][] =
-        'fee_widget';
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['palettes']['__selector__'][] = 'fe_widget';
 
-    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['fields']['fee_widget'] = [
-        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['fee_widget'],
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['metasubselectpalettes']['attr_id']['file']['functions'][] =
+        'fe_widget';
+
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['fields']['fe_widget'] = [
+        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['fe_widget'],
         'exclude'   => true,
         'inputType' => 'select',
         'eval'      => [
@@ -51,8 +53,30 @@ if (in_array('metamodels-contao-frontend-editing', \Contao\ModuleLoader::getActi
         'exclude'   => true,
         'inputType' => 'checkbox',
         'eval'      => [
-            'tl_class'           => 'w50',
+            'tl_class'           => 'w50 m12',
         ],
         'sql'       => "char(1) NOT NULL default ''",
+    ];
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['fields']['useHomeDir'] = [
+        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['useHomeDir'],
+        'exclude'   => true,
+        'inputType' => 'checkbox',
+        'eval'      => [
+            'tl_class'           => 'w50 m12',
+        ],
+        'sql'       => "char(1) NOT NULL default ''",
+    ];
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['fields']['fallbackImage'] = [
+        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['fallbackImage'],
+        'exclude'   => true,
+        'inputType' => 'fileTree',
+        'eval'      => [
+            'fieldType'  => 'radio',
+            'files'      => true,
+            'filesOnly'  => true,
+            'extensions' => $GLOBALS['TL_CONFIG']['validImageTypes'],
+            'tl_class'   => 'w50 w50h',
+        ],
+        'sql'       => "binary(16) NULL",
     ];
 }

--- a/contao/dca/tl_metamodel_dcasetting.php
+++ b/contao/dca/tl_metamodel_dcasetting.php
@@ -29,3 +29,30 @@ $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['metasubselectpalettes']['attr_id'
         'mandatory',
     )
 );
+
+if (in_array('metamodels-contao-frontend-editing', \Contao\ModuleLoader::getActive())) {
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['metasubselectpalettes']['attr_id']['file']['functions'][] =
+        'fee_widget';
+
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['fields']['fee_widget'] = [
+        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['fee_widget'],
+        'exclude'   => true,
+        'inputType' => 'select',
+        'eval'      => [
+            'tl_class'           => 'w50',
+            'mandatory'          => true,
+            'submitOnChange'     => true,
+            'includeBlankOption' => true,
+        ],
+        'sql'       => "varchar(64) NOT NULL default ''",
+    ];
+    $GLOBALS['TL_DCA']['tl_metamodel_dcasetting']['fields']['doNotOverwrite'] = [
+        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['doNotOverwrite'],
+        'exclude'   => true,
+        'inputType' => 'checkbox',
+        'eval'      => [
+            'tl_class'           => 'w50',
+        ],
+        'sql'       => "char(1) NOT NULL default ''",
+    ];
+}

--- a/contao/languages/en/tl_metamodel_dcasetting.php
+++ b/contao/languages/en/tl_metamodel_dcasetting.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of MetaModels/attribute_file.
+ *
+ * (c) 2012-2017 The MetaModels team.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    MetaModels
+ * @subpackage AttributeFile
+ * @author     Richard Henkenjoann <richardhenkenjohann@googlemail.com>
+ * @copyright  2012-2017 The MetaModels team.
+ * @license    https://github.com/MetaModels/attribute_file/blob/master/LICENSE LGPL-3.0
+ * @filesource
+ */
+
+$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['fe_widget'][0]      = 'Frontend Widget';
+$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['fe_widget'][1]      = 'Choose the widget to upload files in the frontend.';
+$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['doNotOverwrite'][0] = 'Preserve existing files';
+$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['doNotOverwrite'][1] = 'Add a numeric suffix to the new file if the file name already exists.';
+$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['useHomeDir'][0]     = 'Use home directory';
+$GLOBALS['TL_LANG']['tl_metamodel_dcasetting']['useHomeDir'][1]     = 'Store the file in the home directory if there is an authenticated user.';
+

--- a/src/MetaModels/Attribute/File/Contao/Widget/IFileWidget.php
+++ b/src/MetaModels/Attribute/File/Contao/Widget/IFileWidget.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MetaModels\Attribute\File\Contao\Widget;
+
+interface IFileWidget
+{
+
+    /**
+     * @return array
+     */
+    public static function getAllowedEval();
+}

--- a/src/MetaModels/Attribute/File/File.php
+++ b/src/MetaModels/Attribute/File/File.php
@@ -183,6 +183,18 @@ class File extends BaseSimple
             $this->handleCustomFileTree($arrFieldDef);
         }
 
+        if ('FE' === TL_MODE && '' !== $arrOverrides['fee_widget']) {
+            $arrFieldDef['inputType'] = $arrOverrides['fee_widget'];
+            $widgetClass = $GLOBALS['TL_FFL'][$arrFieldDef['inputType']];
+
+            $additionalEval = $widgetClass::getAllowedEval();
+            foreach ($additionalEval as $property) {
+                if ($arrOverrides[$property]) {
+                    $arrFieldDef['eval'][$property] = $arrOverrides[$property];
+                }
+            }
+        }
+
         return $arrFieldDef;
     }
 

--- a/src/MetaModels/Attribute/File/File.php
+++ b/src/MetaModels/Attribute/File/File.php
@@ -183,8 +183,8 @@ class File extends BaseSimple
             $this->handleCustomFileTree($arrFieldDef);
         }
 
-        if ('FE' === TL_MODE && '' !== $arrOverrides['fee_widget']) {
-            $arrFieldDef['inputType'] = $arrOverrides['fee_widget'];
+        if ('FE' === TL_MODE && '' !== $arrOverrides['fe_widget']) {
+            $arrFieldDef['inputType'] = $arrOverrides['fe_widget'];
             $widgetClass = $GLOBALS['TL_FFL'][$arrFieldDef['inputType']];
 
             $additionalEval = $widgetClass::getAllowedEval();


### PR DESCRIPTION
## Description

Very dirty code on how we can support **different file widgets** in the Frontend Editing.

1. Every supported file widget (e.g. File Picker, Dropzone…. each of them needs a own implementation) is defined in the `$GLOBALS['TL_FFL']`.
2. Every supported file widget then implements the interface `MetaModels\Attribute\File\Contao\Widget\IFileWidget`.
See for isntance https://github.com/richardhj/metamodels-fee-widget-upload-preview/blob/master/src/Widget/UploadPreview.php
As you can see, the method `getAllowedEval()` gives us the properties that are allowed to set in the field definition. These fields then get set in the field definition, so the widget can run with the settings needed.
3. The widgets with the interface implementing are selectable as widget within the input screen [*click*](https://github.com/MetaModels/attribute_file/pull/61/files#diff-e2a09a92365d013895094701bda0ef64R42)
4. The properties allowed are added to the `eval`. The widget can use the properties [*click*](https://github.com/MetaModels/attribute_file/pull/61/files#diff-427c155aaa3a5060709eadfc3c0543fcR186). Properties can be e.g. (`doNotOverwrite`, `useHomeDir`)
5. The widget extension has to define the properties within the tl_metamodel_dcasetting dca [*click*](https://github.com/MetaModels/attribute_file/pull/61/files#diff-4f9da46d419c83a927fc3498500b7904R33)

Related #57 

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
