### PR TITLE
[RTM] Changed p-Tag into div-Tag

### DIFF
--- a/src/Resources/contao/templates/mm_attr_file_alternative.html5
+++ b/src/Resources/contao/templates/mm_attr_file_alternative.html5
@@ -1,6 +1,6 @@
 <?php if (is_array($this->src)): ?>
 <?php foreach($this->src as $arrFile): ?>
-<p class="<?= $arrFile['class'] ?><?= $this->additional_class ?>">
+<div class="<?= $arrFile['class'] ?><?= $this->additional_class ?>">
 <?php if ($arrFile['isPicture'] && $this->settings->get('file_showImage')): ?>
 <figure class="image_container<?= $arrFile['floatClass'] ?>"<?php if ($arrFile['margin']): ?> style="<?= $arrFile['margin'] ?>"<?php endif; ?>>
 <?php endif; ?>
@@ -29,6 +29,6 @@
     <?php endif; ?>
 </figure>
 <?php endif; ?>
-</p>
+</div>
 <?php endforeach; ?>
 <?php endif; ?>


### PR DESCRIPTION
Figure is an Block-Element -> http://w3c.github.io/html-reference/figure.html
So there should be no p around it ;-)

## Description

Please explain the detailed changes you made here.
Reference any issue number this pull request fixes.

## Checklist
- [ ] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
