### PR TITLE
Update BuildAttributeListener.php

### DIFF
--- a/src/EventListener/BuildAttributeListener.php
+++ b/src/EventListener/BuildAttributeListener.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/attribute_file.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels/attribute_file
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Tenzin Tsarma <git@tsarma.ch>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_file/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */

--- a/src/EventListener/BuildAttributeListener.php
+++ b/src/EventListener/BuildAttributeListener.php
@@ -54,11 +54,12 @@ class BuildAttributeListener
             $this->addAttributeToDefinition($container, $name);
             $properties->getProperty($name . '__sort')->setWidgetType('fileTreeOrder');
 
+            $properties->addProperty($property = new DefaultProperty($name . '__sort'));
+            $property->setWidgetType('fileTreeOrder');
+            
             return;
         }
 
-        $properties->addProperty($property = new DefaultProperty($name . '__sort'));
-        $property->setWidgetType('fileTreeOrder');
 
         $this->addAttributeToDefinition($container, $name);
     }


### PR DESCRIPTION
Double calling of widget creation.

When I enable 'Multiple Selection' to attribute type file, 2 widgets are created. One from the property of type 'fileTree' and another from property of 'fileTreeOrder'.  
So either make only one widget of Type 'fileTree' or put the creation of second property inside the if block.


