### PR TITLE
[RTM] Fix upgrade handler

### DIFF
--- a/src/Helper/UpgradeHandler.php
+++ b/src/Helper/UpgradeHandler.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/attribute_file.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels/attribute_file
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_file/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */

--- a/src/Helper/UpgradeHandler.php
+++ b/src/Helper/UpgradeHandler.php
@@ -82,7 +82,7 @@ class UpgradeHandler
             ->execute();
 
         while ($row = $attributes->fetch(\PDO::FETCH_OBJ)) {
-            if ($this->fieldExists($row->colname . '__sort', $row->tableName)) {
+            if ($this->fieldExists($row->tableName, $row->colname . '__sort')) {
                 continue;
             }
             $this


### PR DESCRIPTION
## Description

This is a hotfix. It fixes every migration failing with error:
```

 An exception occurred while executing 'ALTER TABLE mm_test ADD COLUMN downloads__sort blob NULL':  
                                                                                                           
  SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'downloads__sort'   
```

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
