### PR TITLE
Fix concurrent unbuffered query dead lock

### DIFF
--- a/src/Migration/AddSortFieldMigration.php
+++ b/src/Migration/AddSortFieldMigration.php
@@ -156,11 +156,13 @@ class AddSortFieldMigration extends AbstractMigration
     private function countMissingSortColumns($attributes): int
     {
         $countColumns = 0;
-        $rows = $attributes->fetchAllAssociative();
+        $rows         = $attributes->fetchAllAssociative();
+
         foreach ($rows as $row) {
             if ($this->fieldExists($row['tableName'], $row['colname'] . '__sort')) {
                 continue;
             }
+
             $countColumns++;
         }
 

--- a/src/Migration/AddSortFieldMigration.php
+++ b/src/Migration/AddSortFieldMigration.php
@@ -12,6 +12,7 @@
  *
  * @package    MetaModels/attribute_file
  * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @author     Kim Wormer <info@kim-wormer.de>
  * @copyright  2012-2022 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_file/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -155,8 +156,8 @@ class AddSortFieldMigration extends AbstractMigration
     private function countMissingSortColumns($attributes): int
     {
         $countColumns = 0;
-
-        while ($row = $attributes->fetchAssociative()) {
+        $rows = $attributes->fetchAllAssociative();
+        foreach ($rows as $row) {
             if ($this->fieldExists($row['tableName'], $row['colname'] . '__sort')) {
                 continue;
             }


### PR DESCRIPTION
## Description

We must not perform a query while the results of a previous one are not completely read yet.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] All tests passing
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
