### PR TITLE
Cannot assign null to property

### DIFF
--- a/src/Attribute/File.php
+++ b/src/Attribute/File.php
@@ -529,10 +529,13 @@ class File extends BaseComplex
         }
 
         $toolbox = clone $this->toolboxFile;
+        if ($this->getMetaModel()->isTranslated()) {
+            $toolbox
+                ->setBaseLanguage($this->getMetaModel()->getActiveLanguage())
+                ->setFallbackLanguage($this->getMetaModel()->getFallbackLanguage());
+        }
 
         $toolbox
-            ->setBaseLanguage($this->getMetaModel()->getActiveLanguage())
-            ->setFallbackLanguage($this->getMetaModel()->getFallbackLanguage())
             ->setLightboxId(
                 \sprintf(
                     '%s.%s.%s',


### PR DESCRIPTION
Cannot assign null to property MetaModels\Helper\ToolboxFile::$fallbackLanguage of type string

The parameter for setFallbackLanguage is string and only string. But if the MM is not translatable, the return value from getFallbackLanguage is null. So I got an error for the setFallbackLanguage.